### PR TITLE
Update La comunità: progetti benefit

### DIFF
--- a/La comunità: progetti benefit
+++ b/La comunità: progetti benefit
@@ -10,8 +10,10 @@ altro?
 
 Attività consolidate
 
-minicoder
-
+minicoder --> Il progetto minicoder è iniziato in co-creazione con il nostro cliente Ghelfi Ondulati nel 2018 e quest'anno ha dato i suoi frutti, molte scuole hanno aderito al progetto ed i bambini si sono dimostrati interessati alle attività proposte. 
+Il nostro obbiettivo è quello di introdurre la logica del coding già nei bambini, cercando quindi di inserirli nel mondo dell’informatica, sviluppare il pensiero computazionale ed inoltre imparare a collaborare e lavorare in gruppo. 
+Tramite l'approccio ludico e la collaborazione degli alunni si entra sempre di più nella logica informatica, dapprima tramite veri e propri giochi fino ad arrivare all'utilizzo di Scratch per gli algoritmi più complessi. 
+Ad oggi questo progetto benefit ha impattato una decina di scuole e circa 500 alunni per un totale di ore di corso erogate superiore alle 70.
 hirebitto
 
 SDG: 4,8,10,12,15


### PR DESCRIPTION
Il progetto minicoder è iniziato in co-creazione con il nostro cliente Ghelfi Ondulati nel 2018 e quest'anno ha dato i suoi frutti, molte scuole hanno aderito al progetto ed i bambini si sono dimostrati interessati alle attività proposte. 
Il nostro obbiettivo è quello di introdurre la logica del coding già nei bambini, cercando quindi di inserirli nel mondo dell’informatica, sviluppare il pensiero computazionale ed inoltre imparare a collaborare e lavorare in gruppo. 
Tramite l'approccio ludico e la collaborazione degli alunni si entra sempre di più nella logica informatica, dapprima tramite veri e propri giochi fino ad arrivare all'utilizzo di Scratch per gli algoritmi più complessi. 
Ad oggi questo progetto benefit ha impattato una decina di scuole e circa 500 alunni per un totale di ore di corso erogate superiore alle 70.