### PR TITLE
Update La persona al centro: cura dei dipendenti.md

### DIFF
--- a/La persona al centro: cura dei dipendenti.md
+++ b/La persona al centro: cura dei dipendenti.md
@@ -4,7 +4,8 @@
 
 #### laboratori, 
 
-#### paracadute, --> L'azienda è un posto all'interno del quale le persone possono sviluppare i propri talenti, di conseguenza, si apprezza anche quando un collega decide di lasciarla. Per questo motivo è stata introdotta nel 2019 la tecnica del paracadute, ovvero nel caso in cui un collega decide di andarsene, gli viene data la possibilità di rientrare a far parte dell'azienda entro 12 mesi dopo la partenza con le stesse condizioni contrattuali che aveva in precedenza. Nel momento in cui una persona decide di lasciare l'azienda, i colleghi sono chiamati a votare per la tecnica del paracadute e, se il 10% della forza lavoro è favorevole, questa tecnica può essere applicata. 
+#### paracadute
+L'azienda è un posto all'interno del quale le persone possono sviluppare i propri talenti, di conseguenza, si apprezza anche quando un collega decide di lasciarla. Per questo motivo è stata introdotta nel 2019 la tecnica del paracadute, ovvero nel caso in cui un collega decide di andarsene, gli viene data la possibilità di rientrare a far parte dell'azienda entro 12 mesi dopo la partenza con le stesse condizioni contrattuali che aveva in precedenza. Nel momento in cui una persona decide di lasciare l'azienda, i colleghi sono chiamati a votare per la tecnica del paracadute e, se il 10% della forza lavoro è favorevole, questa tecnica può essere applicata. 
 
 #### banca del tempo?, 
 

--- a/La persona al centro: cura dei dipendenti.md
+++ b/La persona al centro: cura dei dipendenti.md
@@ -4,7 +4,7 @@
 
 #### laboratori, 
 
-#### paracadute, 
+#### paracadute, --> L'azienda è un posto all'interno del quale le persone possono sviluppare i propri talenti, di conseguenza, si apprezza anche quando un collega decide di lasciarla. Per questo motivo è stata introdotta nel 2019 la tecnica del paracadute, ovvero nel caso in cui un collega decide di andarsene, gli viene data la possibilità di rientrare a far parte dell'azienda entro 12 mesi dopo la partenza con le stesse condizioni contrattuali che aveva in precedenza. Nel momento in cui una persona decide di lasciare l'azienda, i colleghi sono chiamati a votare per la tecnica del paracadute e, se il 10% della forza lavoro è favorevole, questa tecnica può essere applicata. 
 
 #### banca del tempo?, 
 


### PR DESCRIPTION
 L'azienda è un posto all'interno del quale le persone possono sviluppare i propri talenti, di conseguenza, si apprezza anche quando un collega decide di lasciarla. Per questo motivo è stata introdotta nel 2019 la tecnica del paracadute, ovvero nel caso in cui un collega decide di andarsene, gli viene data la possibilità di rientrare a far parte dell'azienda entro 12 mesi dopo la partenza con le stesse condizioni contrattuali che aveva in precedenza. Nel momento in cui una persona decide di lasciare l'azienda, i colleghi sono chiamati a votare per la tecnica del paracadute e, se il 10% della forza lavoro è favorevole, questa tecnica può essere applicata. 