### PR TITLE
Update La comunità: progetti benefit.md

### DIFF
--- a/La comunità: progetti benefit.md
+++ b/La comunità: progetti benefit.md
@@ -16,7 +16,7 @@
 Tramite il progetto HireBitto mondora sostiene i pastori locali che portano i loro animali in alpeggio e si impegnano a produrre il formaggio d'alpe, quello che ad oggi si chiama "Storico Ribelle" seguendo le tecniche tradizionali ed inoltre a mantenere l'ecosistema alpino impattando positivamente su di esso. 
 Ad oggi abbiamo 41 forme di formaggio decorate da noi, e tramite il nostro aiuto i produttori di Storico Ribelle si assicurano una corretta retribuzione anche nel caso in cui la stagione in alpeggio non dovesse essere delle migliori per via del clima.
 
-#### Volontariato
+#### Volontariato --> Per ogni giornata di volontariato svolta al di fuori dell'azienda, mondora concede ai dipendenti la possibilità di effettuare una giornata della stessa attività retribuita, fino ad un totale di 5 giornate lavorative a persona. Nel 2019 mondora conta ..... ore impiegate in attività di volontariato all'esterno, inoltre è possibile svolgere ore di volontariato organizzate dall'azienda, come ad esempio l'attività di minicoder o l'attività nei campi. 
 
 SDG: 4,8,10,12,15
 SDG da migliorare: 


### PR DESCRIPTION
Per ogni giornata di volontariato svolta al di fuori dell'azienda, mondora concede ai dipendenti la possibilità di effettuare una giornata della stessa attività retribuita, fino ad un totale di 5 giornate lavorative a persona. Nel 2019 mondora conta 270 ore impiegate in attività di volontariato all'esterno, inoltre è possibile svolgere ore di volontariato organizzate dall'azienda, come ad esempio l'attività di minicoder o l'attività nei campi. 