### PR TITLE
Update L’ambiente intorno a noi.md

### DIFF
--- a/L’ambiente intorno a noi.md
+++ b/L’ambiente intorno a noi.md
@@ -12,7 +12,8 @@
 
 #### Cycle2Work, 
 
-#### Plastic Free & Paper Free
+#### Plastic Free & Paper Free --> mondora è da sempre paper free, in ufficio non viene utilizzata la carta e non ci sono le stampanti. I dipendenti hanno ricevuto un’agenda RockBooks fatta di carta di roccia, prodotta con il minor dispendio di risorse e inquindando meno rispetto alla carta tradizionale. L’azienda aiuta anche i propri clienti a misurare i fogli di carta risparmiati grazie alla digitalizzazione, fornendo un software in grado di monitorare i consumi. Inoltre da ormai due anni mondora ha aderito ad una campagna internazionale contro l'utilizzo della plastica usa e getta acquistando dalla B Corp Dopper delle borraccie per ogni dipendente ed eliminando le bottiglie di plastica dagli uffici. mondora promuove queste pratiche anche all'esterno, presso i clienti e le istituzioni, come ad esempio nelle scuole. 
+
 
 #### Spluga
 


### PR DESCRIPTION
mondora è da sempre un'azienda paper free: in ufficio non viene utilizzata la carta e non ci sono le stampanti. I dipendenti hanno a disposizione delle agende RockBooks, fatte di carta di roccia prodotta con il minor dispendio di risorse e minor inquinamento rispetto alla carta tradizionale. L’azienda aiuta anche i propri clienti a misurare i fogli di carta risparmiati grazie alla digitalizzazione, fornendo un software in grado di monitorare i consumi. Inoltre da ormai due anni mondora ha aderito ad una campagna internazionale contro l'utilizzo della plastica usa e getta tramite l'acquisto di borracce Dopper per ogni dipendente, eliminando così la plastica dagli uffici. mondora promuove queste pratiche anche all'esterno, presso i clienti e le istituzioni, come ad esempio nelle scuole locali Valtellinesi.